### PR TITLE
fix an invalid calc expression

### DIFF
--- a/less/modal.less
+++ b/less/modal.less
@@ -283,7 +283,7 @@ input.modal-text-input {
 html.with-statusbar-overlay {
     // iPhone with statusbar overlay
     .popup {
-        height: ~"-webkit-calc(100% -1rem)";
+        height: ~"-webkit-calc(100% - 1rem)";
         height: ~"calc(100% - 1rem)";
         top: 1rem;
     }


### PR DESCRIPTION
The + and - operators must always be surrounded by whitespace.
