### PR TITLE
 * 修改目标：  * 1.ajax页面请求后，前面同ID的页面仍存在页面,解决后，在将请求到的页面插入前，会移除页面已有的同ID页面 *  * 2.工具栏切换不入栈(已解决)

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -101,7 +101,60 @@
 
         });
     };
+ /*
+   * 
+          多重函数，基于Router.prototype.loadPage的函数修改，进行重构。
+          解决问题：1.工具栏ajax按钮请求也会放入队列，解决后，带有toolbar-tab的a元素，将不放入队列
+          2.ajax页面请求后，前面同ID的页面仍存在页面,解决后，在将请求到的页面插入前，会移除页面已有的同ID页面
+      added by xiaohelong 20151214 xiaohelong2005@gmail.com         
+   */
+  Router.prototype.loadPage = function(url,$target) {
+    //调用getPage函数，返回页面内容page对象 <div class="page"></div>区域
+	
+        // android chrome 在移动端加载页面时不会触发一次‘popstate’事件
+        this.newLoaded && (this.newLoaded = false);
+        this.getPage(url, function(page) {
 
+            var pageid = this.getCurrentPage()[0].id;
+ if(!($target.hasClass("toolbar-tab") ||
+    	         $target[0].hasAttribute("toolbar-tab")))
+      {
+    	 this.pushBack({
+                url: url,
+                pageid: "#" + pageid,
+                id: this.getCurrentStateID()
+            });
+      }
+            //删除全部forward
+            var forward = JSON.parse(this.state.getItem("forward") || "[]");
+            for (var i = 0; i < forward.length; i++) {
+                $(forward[i].pageid).each(function() {
+                    var $page = $(this);
+                    if ($page.data("page-remote")) $page.remove();
+                });
+            }
+            this.state.setItem("forward", "[]");  //clearforward
+ /*
+       * 解决问题：当使用ajax时，会保留旧页面，所以在插入新获取的页面后，插入至整个文档前需要将其remove删除掉，以例保证程序正常运行.
+       * added by xiaohelong 20151214
+       */      
+       var newPageId=$(page).attr("id");
+       $("#"+newPageId).remove();
+       /**
+        *  end added 
+        */
+            page.insertAfter($(".page")[0]);
+            this.animatePages(this.getCurrentPage(), page);
+
+            var id = this.genStateID();
+            this.setCurrentStateID(id);
+
+            this.pushState(url, id);
+
+            this.forwardStack = [];  //clear forward stack
+
+        });
+  }
     /**
      * 页面转场效果
      *
@@ -346,7 +399,8 @@
             }
 
             if (!url || url === "#") return;
-            router.loadPage(url);
+			//router.loadPage(url);
+            router.loadPage(url,$target);
         })
     });
 }(Zepto);

--- a/js/router.js
+++ b/js/router.js
@@ -140,10 +140,13 @@
        */      
        var newPageId=$(page).attr("id");
        $("#"+newPageId).remove();
-       /**
-        *  end added 
-        */
-            page.insertAfter($(".page")[0]);
+        if($(".page")[0])
+          page.insertAfter($(".page")[0]);
+      else
+    	  page.appendTo($("body")[0]);
+      /**
+       *  end added 
+       */
             this.animatePages(this.getCurrentPage(), page);
 
             var id = this.genStateID();


### PR DESCRIPTION
- 修改目标：
- 1.ajax页面请求后，前面同ID的页面仍存在页面,解决后，在将请求到的页面插入前，会移除页面已有的同ID页面 *
- 2.工具栏切换不入栈(已解决)
- 原文如下："注意如果你希望点击工具栏切换页面，一定要用内联页面进行切换，不然会造成重复加载的问题，具体用法参见 light7商城。"
- =====================================================
- 使用方式
- 在a链接元素中，添加toolbar-tab属性或者类
- 解决办法：
- 原理描述：在加载页面开始处，检测具有toolbar-tab属性或类的a元素单击事件，如果是将不送入队列.
- 2.1 在  Router.prototype.loadPage = function(url, )的基础上，添加函数
    Router.prototype.loadPage = function(url,$target);
  2.2并将调用改成新增函数的调用。
    原函数调用 router.loadPage(url, $target.hasClass("no-transition"));
   更改后 router.loadPage(url, $target.hasClass("no-transition"),$target);
