### PR TITLE
解决设置data-type="js" 后 单复选框无法触发默认选中取消事件的BUG

### DIFF
--- a/js/iscroll.js
+++ b/js/iscroll.js
@@ -1657,7 +1657,7 @@
                     this._key(e);
                     break;
                 case 'click':
-                    if (!e._constructed) {
+                    if (!e._constructed && !utils.preventDefaultException(e.target, this.options.preventDefaultException)) {
                         e.preventDefault();
                         e.stopPropagation();
                     }


### PR DESCRIPTION
解决设置data-type="js" 后 单复选框无法触发默认选中取消事件的BUG
