### PR TITLE
将router中的href协议黑名单模式改为白名单模式

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -843,7 +843,7 @@
             'https',
         ];
 
-        if (/^(\w+):\/\/./.test(linkHref)) {
+        if (/^(\w+):\/?./.test(linkHref)) {
             return !~protoWhiteList.indexOf(RegExp.$1)
         }
 

--- a/js/router.js
+++ b/js/router.js
@@ -838,17 +838,13 @@
         var linkEle = $link.get(0);
         var linkHref = linkEle.getAttribute('href');
 
-        var protoBlackList = [
-            'tel:',
-            'javascript:' // jshint ignore:line
+        var protoWhiteList = [
+            'http',
+            'https',
         ];
 
-        if (linkHref) {
-            for (var j = protoBlackList.length - 1; j >= 0; j--) {
-                if (linkHref.indexOf(protoBlackList[j]) === 0) {
-                    return true;
-                }
-            }
+        if (/^(\w+):\/\/./.test(linkHref)) {
+            return !~protoWhiteList.indexOf(RegExp.$1)
         }
 
         //noinspection RedundantIfStatementJS


### PR DESCRIPTION
目前的proto黑名单中只有两个过滤项，除此之外还有mailto，file等还有用户针对打开本地app自定义的url scheme，因此更改原有router中href的protocol过滤方式，将黑名单改为白名单，只保留了http和https两个白名单协议，noscheme情况测试通过。
