### PR TITLE
修复图片浏览器bug, issue#386

### DIFF
--- a/js/photo-browser.js
+++ b/js/photo-browser.js
@@ -149,7 +149,7 @@
             pb.attachEvents(true);
             // Delete from DOM
             if (pb.params.type === 'standalone') {
-                pb.container.removeClass('photo-browser-in').addClass('photo-browser-out').transitionEnd(function () {
+                pb.container.removeClass('photo-browser-in').addClass('photo-browser-out').animationEnd(function () {
                     pb.container.remove();
                 });
             }


### PR DESCRIPTION
修复issue #386,更改transitionEnd方法为animationEnd,确保关闭后删除原有browser container。
