### PR TITLE
修正js如果在head中引入，则取不到body的bug

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -441,6 +441,6 @@
         modalButtonOk: '确定',
         modalButtonCancel: '取消',
         modalPreloaderTitle: '加载中',
-        modalContainer : document.body
+        modalContainer : document.body ? document.body : 'body'
     };
 }(Zepto);


### PR DESCRIPTION
model.js 的 defaults.modalContainer，如果js是在head部分引入，而不是在body底部引入的，那么 defaults.modalContainer 对应的 document.body 就会取成空值。
添加一个判断，如果 document.body 取不到的话，就用字符串 body 来替换，保证$(defaults.modalContainer) 能取到对应的节点。
