### PR TITLE
解决安卓QQ日历弹出软键盘的问题

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -653,8 +653,8 @@
         // Input Events
         function openOnInput(e) {
             e.preventDefault();
-            // 安卓微信webviewreadonly的input依然弹出软键盘问题修复
-            if ($.device.isWeixin && $.device.android && p.params.inputReadOnly) {
+            // 安卓微信和QQ webviewreadonly的input依然弹出软键盘问题修复
+            if (($.device.isWeixin || $.device.isQQ) && $.device.android && p.params.inputReadOnly) {
                 /*jshint validthis:true */
                 this.focus();
                 this.blur();

--- a/js/device.js
+++ b/js/device.js
@@ -101,6 +101,7 @@ Device/OS Detection
 
     // keng..
     device.isWeixin = /MicroMessenger/i.test(ua);
+    device.isQQ = /MQQBrowser/i.test(ua) && /QQ\//i.test(ua);
 
     $.device = device;
 })(Zepto);


### PR DESCRIPTION
安卓的QQ内置浏览器和微信一样，即使input设置了readonly也会弹出软键盘。
