### PR TITLE
jQuery兼容处理

### DIFF
--- a/dist/js/sm.js
+++ b/dist/js/sm.js
@@ -17,8 +17,9 @@
     };
 
     $.smConfig = $.extend(defaults, $.config);
-
-}(Zepto);
+    window.Zepto = $;
+    window.Zepto.fn.forEach = $.fn.forEach || $.fn.map;
+}(window.Zepto || window.jQuery);
 
 + function($) {
     "use strict";
@@ -1865,6 +1866,7 @@ Device/OS Detection
                 if (isMoved || isTouched) return;
                 // e.preventDefault();
                 isTouched = true;
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchStartX = touchCurrentY = e.type === 'touchstart' ? e.targetTouches[0].pageX : e.pageX;
                 touchStartY = touchCurrentY = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;
                 touchStartTime = (new Date()).getTime();
@@ -1875,7 +1877,7 @@ Device/OS Detection
             }
             function handleTouchMove (e) {
                 if (!isTouched) return;
-
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchCurrentX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
                 touchCurrentY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
                 if (typeof isScrolling === 'undefined') {
@@ -1977,13 +1979,14 @@ Device/OS Detection
 
             /**
              * 处理选择年份时的手势操作事件
-             * 
+             *
              * Start - edit by JSoon
              */
             function handleYearTouchStart (e) {
                 if (isMoved || isTouched) return;
                 // e.preventDefault();
                 isTouched = true;
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchStartX = touchCurrentY = e.type === 'touchstart' ? e.targetTouches[0].pageX : e.pageX;
                 touchStartY = touchCurrentY = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;
                 touchStartTime = (new Date()).getTime();
@@ -1995,7 +1998,7 @@ Device/OS Detection
 
             function handleYearTouchMove (e) {
                 if (!isTouched) return;
-
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchCurrentX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
                 touchCurrentY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
                 if (typeof isScrolling === 'undefined') {
@@ -2089,7 +2092,7 @@ Device/OS Detection
             p.container.find('.current-year-value').on('click', handleYearSelector);
 
             // 选择月份
-            p.container.find('.current-month-value').on('click', handleMonthSelector); 
+            p.container.find('.current-month-value').on('click', handleMonthSelector);
             /**
              * End - edit by JSoon
              */
@@ -2098,7 +2101,7 @@ Device/OS Detection
             if (p.params.touchMove) {
                 /**
                  * 给年份选择器绑定手势操作事件
-                 * 
+                 *
                  * Start - edit by JSoon
                  */
                 p.yearsPickerWrapper.on($.touchEvents.start, handleYearTouchStart);
@@ -2133,7 +2136,7 @@ Device/OS Detection
         };
 
         // Calendar Methods
-        
+
         /**
          * 1. 生成年份和月份选择器DOM结构
          * 2. 年份选择和月份选择的pick事件函数
@@ -2252,8 +2255,8 @@ Device/OS Detection
         };
         /**
          * End - edit by JSoon
-         */ 
-        
+         */
+
         p.daysInMonth = function (date) {
             var d = new Date(date);
             return new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
@@ -2669,7 +2672,7 @@ Device/OS Detection
             var layoutDate = p.value && p.value.length ? p.value[0] : new Date().setHours(0,0,0,0);
             /**
              * 生成年份组和月份组DOM
-             * 
+             *
              * Start - edit by JSoon
              */
             var prevYearsHTML = p.yearsGroupHTML(layoutDate, 'prev');
@@ -2707,7 +2710,7 @@ Device/OS Detection
 
             /**
              * 将年份组/月份组DOM添加document中
-             * 
+             *
              * Start - edit by JSoon
              */
             pickerHTML =
@@ -2782,7 +2785,7 @@ Device/OS Detection
                  * 修复[#308](https://github.com/sdc-alibaba/SUI-Mobile/issues/308)
                  * 场景：内联页面中存在日历控件的input
                  * 问题：因未在关闭时unbind click openOnInput事件导致多次调用p.open()而生成多个日历
-                 * 
+                 *
                  * Start - edit by JSoon
                  */
                 $(document).on('beforePageSwitch', function() {
@@ -2844,7 +2847,7 @@ Device/OS Detection
                 /**
                  * 获取全局年份组及其wrapper的zepto对象
                  * 获取全局月份组wrapper的zepto对象
-                 * 
+                 *
                  * Start - edit by JSoon
                  */
                 p.yearsPickerWrapper = p.container.find('.picker-calendar-years-picker-wrapper');
@@ -2864,7 +2867,7 @@ Device/OS Detection
                 // Set initial translate
                 /**
                  * 初始化年份组过渡动画位置
-                 * 
+                 *
                  * Start - edit by JSoon
                  */
                 p.yearsTranslate = 0;
@@ -3178,6 +3181,7 @@ Device/OS Detection
                 if (isMoved || isTouched) return;
                 e.preventDefault();
                 isTouched = true;
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchStartY = touchCurrentY = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;
                 touchStartTime = (new Date()).getTime();
 
@@ -3188,6 +3192,7 @@ Device/OS Detection
                 if (!isTouched) return;
                 e.preventDefault();
                 allowItemClick = false;
+                e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
                 touchCurrentY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
                 if (!isMoved) {
                     // First move
@@ -3295,7 +3300,6 @@ Device/OS Detection
             col.container[0].f7DestroyPickerCol = function () {
                 col.destroyEvents();
             };
-
             col.initEvents();
 
         };
@@ -3429,7 +3433,7 @@ Device/OS Detection
 
         p.opened = false;
         p.open = function () {
-        
+
             if (!p.opened) {
 
                 // Layout
@@ -3440,12 +3444,12 @@ Device/OS Detection
                     p.container = $(p.pickerHTML);
                     p.container.addClass('picker-modal-inline');
                     $(p.params.container).append(p.container);
-                    
+
                 }
                 else {
 
                     p.container = $($.pickerModal(p.pickerHTML));
-                    
+
                     $(p.container)
                         .on('close', function () {
                             onPickerClose();
@@ -3683,7 +3687,7 @@ Device/OS Detection
 
         me.extend = function(target, obj) {
             for (var i in obj) {  // jshint ignore:line
-                    target[i] = obj[i]; 
+                    target[i] = obj[i];
             }
         };
 
@@ -3930,7 +3934,7 @@ Device/OS Detection
 
             snapThreshold: 0.334,
 
-            // INSERT POINT: OPTIONS 
+            // INSERT POINT: OPTIONS
 
             startX: 0,
             startY: 0,
@@ -3996,7 +4000,7 @@ Device/OS Detection
 
         // INSERT POINT: NORMALIZATION
 
-        // Some defaults    
+        // Some defaults
         this.x = 0;
         this.y = 0;
         this.directionX = 0;
@@ -5884,8 +5888,10 @@ Device/OS Detection
                 } else {
                     return this.scroller.getComputedPosition().y * -1;
                 }
-            } else {
-                return this.$pageContent.scrollTop(top, dur);
+            }else if(top !== undefined){
+            	return this.$pageContent.scrollTop(top, dur);
+            }else {
+                return this.$pageContent.scrollTop();
             }
             return this;
         },
@@ -6335,6 +6341,7 @@ Device/OS Detection
             isTouched = true;
             isScrolling = undefined;
             wasScrolled = undefined;
+            e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
             touchesStart.x = e.type === 'touchstart' ? e.targetTouches[0].pageX : e.pageX;
             touchesStart.y = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;
             touchStartTime = (new Date()).getTime();
@@ -6344,6 +6351,7 @@ Device/OS Detection
 
         function handleTouchMove(e) {
             if (!isTouched) return;
+            e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
             var pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
             var pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
             if (typeof isScrolling === 'undefined') {
@@ -6690,6 +6698,7 @@ Device/OS Detection
             if (!(swipePanelCloseOpposite || swipePanelOnlyClose)) {
                 if ($('.panel.active').length > 0 && !panel.hasClass('active')) return;
             }
+            e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
             touchesStart.x = e.type === 'touchstart' ? e.targetTouches[0].pageX : e.pageX;
             touchesStart.y = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;
             if (swipePanelCloseOpposite || swipePanelOnlyClose) {
@@ -6724,6 +6733,7 @@ Device/OS Detection
             if (!isTouched) return;
             if(!panel[0]) return;
             if (e.f7PreventPanelSwipe) return;
+            e.targetTouches = e.targetTouches || e.originalEvent.changedTouches;
             var pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
             var pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
             if (typeof isScrolling === 'undefined') {
@@ -7989,9 +7999,9 @@ Device/OS Detection
         // 如果 panel 的 effect 是 reveal 时,似乎是 page 的动画或别的样式原因导致了 transitionEnd 时间不会触发
         // 这里暂且处理一下
         $('body').removeClass('panel-closing');
-        $.allowPanelOpen = true;  
+        $.allowPanelOpen = true;
     });
-   
+
     $(window).on('pageInit', function() {
         $.hideIndicator();
         $.lastPosition({


### PR DESCRIPTION
jQuery2.0 替代 Zepto 兼容处理，基本测试通过。
jQuery虽然体积比Zepto稍大，但是功能、扩展、插件都要丰富许多，极大提升开发效率。
结合浏览器expires，流量损耗几乎可以忽略（50K还不如一张图片），少量的修改兼容jQuery是值得的。
满足究极开发者要求的同时，也兼顾一下普通开发者需求。
