### PR TITLE
更新城市选择 当数据源第一个包含三级省市区的时候 初次加载 区不显示

### DIFF
--- a/js/city-picker.js
+++ b/js/city-picker.js
@@ -44,8 +44,7 @@
         return d.name;
     });
     var initCities = sub(raw[0]);
-    var initDistricts = [""];
-
+    var initDistricts = getDistricts(provinces[0],initCities[0]);
     var currentProvince = provinces[0];
     var currentCity = initCities[0];
     var currentDistrict = initDistricts[0];


### PR DESCRIPTION
修复 当数据源第一个包含三级省市区的时候 初次加载 区不显示
