### PR TITLE
Safari can not delete dataset attribute in strict mode

### DIFF
--- a/js/zepto-adapter.js
+++ b/js/zepto-adapter.js
@@ -136,7 +136,7 @@
             for (var i = 0; i < this.length; i++) {
                 var el = this[i];
                 // delete multiple data in dataset
-                if (key in tmpData) delete el.dataset[key];
+                if (key in tmpData && 'undefined' !== typeof el.dataset[key]) delete el.dataset[key];
 
                 if (!el.__eleData) el.__eleData = {};
                 el.__eleData[key] = value;


### PR DESCRIPTION
'Unable to delete property' on Safari when trying to delete dataset attribute in strict mode