### PR TITLE
fix error when set data in safari

### DIFF
--- a/js/zepto-adapter.js
+++ b/js/zepto-adapter.js
@@ -136,7 +136,7 @@
             for (var i = 0; i < this.length; i++) {
                 var el = this[i];
                 // delete multiple data in dataset
-                if (key in tmpData) delete el.dataset[key];
+                // if (key in tmpData) delete el.dataset[key];
 
                 if (!el.__eleData) el.__eleData = {};
                 el.__eleData[key] = value;


### PR DESCRIPTION
在IOS 10.3.1的Safari里面，尝试对原生DOM对象的dataset做delete操作，会报`TypeError: Unable to delete property.`。在StackOverflow上面也有类似的问题[http://stackoverflow.com/questions/28973603/unable-to-delete-property-on-safari-when-trying-to-delete-dataset-attribute-in](http://stackoverflow.com/questions/28973603/unable-to-delete-property-on-safari-when-trying-to-delete-dataset-attribute-in)

仔细看了方法`$.fn.data`，在读取data的时候，优先取的__eleData，而写入的时候也会写入__eleData。所以`if (key in tmpData) delete el.dataset[key];`是多余的，而且tmpData里面有，不等于el.dataset[key]就一定有值的。