### PR TITLE
修复 当 input 类型为 range 时，FastClick 的相关错误

### DIFF
--- a/js/fastclick.js
+++ b/js/fastclick.js
@@ -344,7 +344,7 @@
         var length;
 
         // Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-        var unsupportedType = ['date', 'time', 'month', 'number', 'email'];
+        var unsupportedType = ['date', 'time', 'month', 'number', 'email', 'range'];
         if (deviceIsIOS && targetElement.setSelectionRange && unsupportedType.indexOf(targetElement.type) === -1) {
             length = targetElement.value.length;
             targetElement.setSelectionRange(length, length);


### PR DESCRIPTION
当输入框(input)类型为范围选择器(range)时，执行 fastclick 将导致以下错误
```javascript
Failed to read the 'setSelectionRange' property from 'HTMLInputElement': The input element's type ('range')
```

查阅以前的 issue 发现出现过类似问题，只不过并未处理范围选择器，只是处理了number与email的类型 (https://github.com/sdc-alibaba/SUI-Mobile/commit/dad2b3202a8a0f293cf98afecf803ae6d23f300c)

根据 https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange 的指引，范围选择器(range) 不支持 setSelectionRange 方法。

目前修复方法是把 范围选择器(range) 加入到 FastClick.prototype.focus 的不支持的类型(unsupportedType)中去