### PR TITLE
fixed trigger click event get a wrong targetElement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _site/*
 docs/demos/test.html
 docs/assets/js/test.js
 test
+.idea

--- a/js/fastclick.js
+++ b/js/fastclick.js
@@ -704,6 +704,7 @@
      * @returns {boolean}
      */
     FastClick.prototype.onClick = function(event) {
+        this.targetElement = event.target;
         var permitted;
 
         // It's possible for another FastClick-like library delivered with third-party code to fire a click event before FastClick does (issue #44). In that case, set the click-tracking flag back to false and return early. This will cause onTouchEnd to return early.


### PR DESCRIPTION
修复使用js trigger click 时，需要触发两次，sui 使用了`fastclick`，原本可以通过给对应的element添加`needsclick`的 css class 来进行触发原生的`click`事件的，然而代码中只有在`touchstart`才对`targetElement`进行赋值，在`onclick`事件没有，导致`(/\bneedsclick\b/).test(target.className)`一直为`false`，因为`target`是上一次触发`touchstart`的`target`。
#378 
#748 